### PR TITLE
MEM-404 fix Drag and Drop bug

### DIFF
--- a/modules/core/client/scss/components/file-browser.scss
+++ b/modules/core/client/scss/components/file-browser.scss
@@ -858,6 +858,12 @@ $fb-upload-target-border: 2px dashed #BBB;
     }
 }
 
+.dragover {
+    background: $fb-upload-target-hover-bg;
+    border: $fb-upload-target-border;
+    border-color: #CCC;
+}
+
 .fb-upload-target-content {
     position: absolute;
     top: 3.85rem;

--- a/modules/core/client/services/core.dialog.service.js
+++ b/modules/core/client/services/core.dialog.service.js
@@ -1,0 +1,42 @@
+
+"use strict";
+
+angular.module('core')
+.service('DnDBackgroundBlockService',  DnDBackgroundBlockService );
+
+function DnDBackgroundBlockService() {
+	var dropTargetId = 'dropzone';
+	return {
+		addEventListeners: addEventListeners,
+		removeEventListeners: removeEventListeners
+	};
+	function blockEvent(e) {
+		e = e || event;
+		var element = angular.element(e.target);
+		var cnt = 0;
+		do {
+			var elementId = element.attr('id');
+			if (element.attr('id') === dropTargetId) {
+				//console.log("OK ", e.type);
+				return;
+			}
+			element = element.parent();
+			cnt++;
+		} while(cnt < 10 && element && element.tagname !== 'body');
+		// console.log('prevent on ' , dropTargetId);
+		e.preventDefault();
+	}
+
+	function addEventListeners(targetId) {
+		dropTargetId = targetId || 'dropzone';
+		// console.log("Add event listeners");
+		window.addEventListener("drop", blockEvent, false);
+		window.addEventListener("dragover", blockEvent, false);
+	}
+
+	function removeEventListeners() {
+		// console.log("remove event listeners");
+		window.removeEventListener("drop", blockEvent, false);
+		window.removeEventListener("dragover", blockEvent, false);
+	}
+}

--- a/modules/documents/client/directives/documents.manager.upload.directive.js
+++ b/modules/documents/client/directives/documents.manager.upload.directive.js
@@ -1,6 +1,7 @@
 'use strict';
 angular.module('documents')
-	.directive('documentMgrUploadModal',['$rootScope', '$modal', '$log', '$timeout', '_', 'DocumentsUploadService', 'DocumentMgrService', function ($rootScope, $modal, $log, $timeout, _, DocumentsUploadService, DocumentMgrService){
+	.directive('documentMgrUploadModal',['$rootScope', '$modal', '$log', '$timeout', '_', 'DocumentsUploadService', 'DocumentMgrService', 'DnDBackgroundBlockService',
+		function ($rootScope, $modal, $log, $timeout, _, DocumentsUploadService, DocumentMgrService, DnDBackgroundBlockService){
 		return {
 			restrict: 'A',
 			scope: {
@@ -11,6 +12,7 @@ angular.module('documents')
 				parentId: '='
 			},
 			link: function (scope, element, attrs) {
+				DnDBackgroundBlockService.addEventListeners();
 				element.on('click', function () {
 					$modal.open({
 						animation: true,
@@ -70,9 +72,11 @@ angular.module('documents')
 
 						}
 					}).result.then(function (data) {
+						DnDBackgroundBlockService.removeEventListeners();
 							//$log.debug(data);
 						})
 						.catch(function (err) {
+							DnDBackgroundBlockService.removeEventListeners();
 							//$log.error(err);
 						});
 				});

--- a/modules/documents/client/views/document-manager-upload.html
+++ b/modules/documents/client/views/document-manager-upload.html
@@ -5,7 +5,7 @@
 	<div class="fb-upload-target-container">
 
 		<!-- UPLOAD TARGET -->
-		<div class="fb-upload-target" 
+		<div class="fb-upload-target" id="dropzone"
 			ngf-drop 
 			ngf-select
 			ng-model="files"


### PR DESCRIPTION
Port the fix from EPIC which fixes the problem of accidental drops onto the background.  Users could accidentally drop a dozen files onto the background during a drag-n-drop operation. The result was these dozen files would open in new tabs.  This fix blocks any drop except onto the dropzone.
For MEM-admin this only applies to the Doc Manager upload.