### PR TITLE
MEM-399 and 395 Document display and download file names

### DIFF
--- a/modules/core/client/components/fn-filename/README.md
+++ b/modules/core/client/components/fn-filename/README.md
@@ -1,0 +1,35 @@
+# Filename Validator
+
+Provides a filename validation along with preserving the original file's extension
+
+## Usage
+
+Add `fn-filename` attribute to a text input.  Provide the file extension in `fn-extension`. Optionally, provide the ID of a DOM element to display error messages.
+The `fn-filename` directive requires the input has a ng-model.
+
+Sample HTML
+```
+<form name="editFileForm" novalidate>
+...
+<div class="form-group file-type" x-show-errors>
+    <label for="documentFileName" class="control-label">File Name</label>
+    <span id="fileNameError" ng-show="editFileForm.documentFileName.$invalid" class="help-block"></span>
+    <input class="form-control" id="documentFileName" name="documentFileName" type="text" ng-model="documentFileName"
+        fn-filename fn-extension="{{extension}}" fn-error="fileNameError">
+</div>
+...   
+</form> 
+```
+
+Sample controller
+```
+    // ng-model
+    $scope.documentFileName = documentFileName;
+    // fn-extension
+    $scope.extension = documentFileName.split('.').pop();
+```
+
+
+
+
+

--- a/modules/core/client/components/fn-filename/index.js
+++ b/modules/core/client/components/fn-filename/index.js
@@ -1,0 +1,75 @@
+'use strict';
+
+(function() {
+	var NOT_ALLOWED = 'These characters are not allowed: /?<>:*|":';
+	var NO_CONTROL = 'Control characters are not allowed';
+	var NO_PERIOD = "Names shouldn't begin with a period";
+	var RESERVED = 'Can not use reserved file names like COM0, PRN, etc';
+	var NO_ALL_PERIOD = 'Names can not be just periods';
+	var REQUIRED = 'Required';
+
+	angular.module('core')
+	// fn-filename
+	.directive('fnFilename', function () {
+		return {
+			require: 'ngModel',
+			restrict: 'A',
+			link: function (scope, element, attributes, ngModel) {
+				var extension = attributes.fnExtension; // fn-extension
+				var $error;
+				if (attributes.fnError) { // fn-error
+					var errorId = "#" + attributes.fnError;
+					$error = angular.element(document.querySelector(errorId));
+				}
+				element.on('focus', function () {
+					if (extension) {
+						var m = element.val();
+						m = m.substring(0, m.indexOf(extension) - 1);
+						element.val(m);
+					}
+				});
+				element.on('blur', function () {
+					if (extension) {
+						var m = element.val();
+						ngModel.$setViewValue( m + '.' + extension);
+					}
+				});
+				ngModel.$validators.filename = function (modelValue, viewValue) {
+					var input = modelValue;
+					var errMsg = '';
+					if (input) {
+						errMsg = validateFilename(input, extension);
+					} else {
+						errMsg = REQUIRED;
+					}
+					if ($error) {
+						$error.text(errMsg);
+					}
+					return errMsg === '';
+				};
+			}
+		};
+
+		function validateFilename(input, extension) {
+			var illegalRe = /[\/\?<>\\:\*\|":]/g; // basic illegal filename characters
+			var controlRe = /[\x00-\x1f\x80-\x9f]/g; // no control characters
+			var windowsReservedRe = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])(\..*)?$/i;
+			var leadingRe = /^\.+/; // no names beginning with .
+			var reservedRe = /^\.+$/; // no names like ".", ".."
+			var result = '';
+			if (input.match(illegalRe)) {
+				result = NOT_ALLOWED;
+			} else if (input.match(controlRe)) {
+				result = NO_CONTROL;
+			} else if (input.match(leadingRe)) {
+				result = NO_PERIOD;
+			} else if (!extension && input.match(windowsReservedRe)) {
+				result = RESERVED;
+			} else if (input.match(reservedRe)) {
+				result = NO_ALL_PERIOD;
+			}
+			return result;
+		}
+	})
+	;
+})();

--- a/modules/documents/client/controllers/documents.client.controllers.js
+++ b/modules/documents/client/controllers/documents.client.controllers.js
@@ -692,7 +692,7 @@ function controllerModalPdfViewer($modalInstance, $scope, pdf, pdfobject, Docume
 
 	Document.lookup(pdfobject._id)
 	.then(function (d) {
-		$scope.documentName = d.displayName || d.documentFileName || d.internalOriginalName;
+		$scope.documentName = d.displayName;
 		$scope.$apply();
 	});
 

--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -303,10 +303,6 @@ angular.module('documents')
 							//$log.debug('...currentNode (' + self.currentNode.model.name + ') got '+ _.size(result.data ) + '.');
 
 							self.currentFiles = _.map(result.data, function(f) {
-								// making sure that the displayName is set...
-								if (_.isEmpty(f.displayName)) {
-									f.displayName = f.documentFileName || f.internalOriginalName;
-								}
 								f.link =  window.location.protocol + '//' + window.location.host + '/api/document/'+ f._id+'/fetch';
 								if (_.isEmpty(f.dateUploaded) && !_.isEmpty(f.oldData)) {
 									var od = JSON.parse(f.oldData);
@@ -419,9 +415,9 @@ angular.module('documents')
 						}, function(docs) {
 							var msg = "";
 							var theDocs = [];
-							if (docs.data.message && docs.data.message[0] && docs.data.message[0].documentFileName) {
+							if (docs.data.message && docs.data.message[0] && docs.data.message[0].displayName) {
 								_.each(docs.data.message, function (d) {
-									theDocs.push(d.documentFileName);
+									theDocs.push(d.displayName);
 								});
 								msg = 'This action cannot be completed as the following documents are in the folder: ' + theDocs + '.';
 							} else {
@@ -439,7 +435,7 @@ angular.module('documents')
 					return self.deleteDocument(doc._id)
 						.then(function(result) {
 							self.selectNode(self.currentNode.model.id); // will mark as not busy...
-							var name = doc.displayName || doc.documentFileName || doc.internalOriginalName;
+							var name = doc.displayName;
 							AlertService.success('Delete File', 'The selected file was deleted.');
 						}, function(error) {
 							$log.error('deleteFile error: ', JSON.stringify(error));
@@ -539,7 +535,7 @@ angular.module('documents')
 						});
 						_.each(self.checkedFiles, function(o) {
 							if (o.userCan.delete) {
-								var name = o.displayName || o.documentFileName || o.internalOriginalName;
+								var name = o.displayName;
 								self.deleteSelected.confirmItems.push(name);
 								self.deleteSelected.deleteableFiles.push(o);
 							}
@@ -557,8 +553,8 @@ angular.module('documents')
 						.then(function(result) {
 							//$log.debug('Publish File results ', JSON.stringify(result));
 							//$log.debug('Refreshing current directory...');
-							var published = _.map(result, function(o) { if (o.isPublished) return o.displayName || o.documentFileName || o.internalOriginalName; });
-							var unpublished = _.map(result, function(o) { if (!o.isPublished) return o.displayName || o.documentFileName || o.internalOriginalName; });
+							var published = _.map(result, function(o) { if (o.isPublished) return o.displayName; });
+							var unpublished = _.map(result, function(o) { if (!o.isPublished) return o.displayName; });
 							self.selectNode(self.currentNode.model.id);
 							AlertService.success(_.size(published) + ' of ' + _.size(files) + ' files successfully published.');
 						}, function(err) {
@@ -576,8 +572,8 @@ angular.module('documents')
 						.then(function(result) {
 							//$log.debug('Unpublish File results ', JSON.stringify(result));
 							//$log.debug('Refreshing current directory...');
-							var published = _.map(result, function(o) { if (o.isPublished) return o.displayName || o.documentFileName || o.internalOriginalName; });
-							var unpublished = _.map(result, function(o) { if (!o.isPublished) return o.displayName || o.documentFileName || o.internalOriginalName; });
+							var published = _.map(result, function(o) { if (o.isPublished) return o.displayName; });
+							var unpublished = _.map(result, function(o) { if (!o.isPublished) return o.displayName; });
 							self.selectNode(self.currentNode.model.id);
 							AlertService.success(_.size(unpublished) + ' of ' + _.size(files) + ' files successfully unpublished.');
 						}, function(err) {
@@ -609,9 +605,9 @@ angular.module('documents')
 						}, function (docs) {
 							var theDocs = [];
 							var msg = "";
-							if (docs.message && docs.message[0] && docs.message[0].documentFileName) {
+							if (docs.message && docs.message[0] && docs.message[0].displayName) {
 								_.each(docs.message, function (d) {
-									theDocs.push(d.documentFileName);
+									theDocs.push(d.displayName);
 								});
 								msg = 'This action cannot be completed as the following documents are published: ' + theDocs + '.  Please unpublish each document and attempt your action again.';
 							} else {
@@ -661,7 +657,7 @@ angular.module('documents')
 								self.publishSelected.unpublishableFiles.push(o);
 							}
 							if (canDoSomething) {
-								var name = o.displayName || o.documentFileName || o.internalOriginalName;
+								var name = o.displayName;
 								self.publishSelected.confirmItems.push(name);
 							}
 						});
@@ -755,7 +751,7 @@ angular.module('documents')
 						});
 						_.each(self.checkedFiles, function(o) {
 							if (o.userCan.write) {
-								var name = o.displayName || o.documentFileName || o.internalOriginalName;
+								var name = o.displayName;
 								self.moveSelected.confirmItems.push(name);
 								self.moveSelected.moveableFiles.push(o);
 							}

--- a/modules/documents/client/directives/documents.manager.edit.directive.js
+++ b/modules/documents/client/directives/documents.manager.edit.directive.js
@@ -36,6 +36,7 @@ angular.module('documents')
 
 							$scope.originalName = obj.displayName;
 							$scope.doc = obj;
+							$scope.extension = $scope.doc.documentFileName.split('.').pop();
 							// any dates going to the datepicker need to be javascript Date objects...
 							$scope.doc.documentDate = _.isEmpty(obj.documentDate) ? null : moment(obj.documentDate).toDate();
 							$scope.datePicker = {

--- a/modules/documents/client/directives/documents.manager.edit.directive.js
+++ b/modules/documents/client/directives/documents.manager.edit.directive.js
@@ -34,7 +34,7 @@ angular.module('documents')
 								showWeeks: false
 							};
 
-							$scope.originalName = obj.displayName || obj.documentFileName || obj.internalOriginalName;
+							$scope.originalName = obj.displayName;
 							$scope.doc = obj;
 							// any dates going to the datepicker need to be javascript Date objects...
 							$scope.doc.documentDate = _.isEmpty(obj.documentDate) ? null : moment(obj.documentDate).toDate();

--- a/modules/documents/client/directives/documents.manager.link.directive.js
+++ b/modules/documents/client/directives/documents.manager.link.directive.js
@@ -71,11 +71,6 @@ angular.module('documents')
 				self.applySort = function() {
 					// sort ascending first...
 					self.currentFiles = _(self.unsortedFiles).chain().sortBy(function (f) {
-						// more making sure that the displayName is set...
-						if (_.isEmpty(f.displayName)) {
-							f.displayName = f.documentFileName || f.internalOriginalName;
-						}
-
 						if (self.sorting.column === 'name') {
 							return _.isEmpty(f.displayName) ? null : f.displayName.toLowerCase();
 						} else if (self.sorting.column === 'author') {
@@ -173,11 +168,6 @@ angular.module('documents')
 								//$log.debug('...currentNode (' + self.currentNode.model.name + ') got '+ _.size(result.data ) + '.');
 
 								self.unsortedFiles = _.map(result.data, function(f) {
-
-									// making sure that the displayName is set...
-									if (_.isEmpty(f.displayName)) {
-										f.displayName = f.documentFileName || f.internalOriginalName;
-									}
 									if (_.isEmpty(f.dateUploaded) && !_.isEmpty(f.oldData)) {
 										var od = JSON.parse(f.oldData);
 										//console.log(od);

--- a/modules/documents/client/directives/documents.manager.move.directive.js
+++ b/modules/documents/client/directives/documents.manager.move.directive.js
@@ -74,11 +74,6 @@ angular.module('documents')
 							self.applySort = function () {
 								// sort ascending first...
 								self.currentFiles = _(self.unsortedFiles).chain().sortBy(function (f) {
-									// more making sure that the displayName is set...
-									if (_.isEmpty(f.displayName)) {
-										f.displayName = f.documentFileName || f.internalOriginalName;
-									}
-
 									if (self.sorting.column === 'name') {
 										return _.isEmpty(f.displayName) ? null : f.displayName.toLowerCase();
 									} else if (self.sorting.column === 'author') {
@@ -168,10 +163,6 @@ angular.module('documents')
 											//$log.debug('...currentNode (' + self.currentNode.model.name + ') got '+ _.size(result.data ) + '.');
 
 											self.unsortedFiles = _.map(result.data, function (f) {
-												// making sure that the displayName is set...
-												if (_.isEmpty(f.displayName)) {
-													f.displayName = f.documentFileName || f.internalOriginalName;
-												}
 												if (_.isEmpty(f.dateUploaded) && !_.isEmpty(f.oldData)) {
 													var od = JSON.parse(f.oldData);
 													//console.log(od);

--- a/modules/documents/client/views/document-manager-edit.html
+++ b/modules/documents/client/views/document-manager-edit.html
@@ -45,12 +45,10 @@
 			</span>
 		</div>
 
-		<!--
 		<div ng-if="doc._schemaName === 'Document'" class="form-group file-type" x-show-errors>
 			<label for="documentFileName" class="control-label">File Name</label>
 			<input class="form-control" id="documentFileName" name="documentFileName" type="text" ng-model="doc.documentFileName" ng-blur="validate()">
 		</div>
-		-->
 
 		<div class="row form-group">
 			<div class="col-sm-12">

--- a/modules/documents/client/views/document-manager-edit.html
+++ b/modules/documents/client/views/document-manager-edit.html
@@ -20,6 +20,14 @@
 			<input class="form-control" id="displayName" name="displayName" type="text" ng-model="doc.displayName" required ng-blur="validate()">
 		</div>
 
+		<div ng-if="doc._schemaName === 'Document'" class="form-group file-type" x-show-errors>
+			<label for="documentFileName" class="control-label">File Name
+				<span class="text-danger " id="fileNameExtError" ng-show="editFileForm.documentFileName.$invalid"></span>
+			</label>
+			<input class="form-control" id="documentFileName" name="documentFileName" type="text" ng-model="doc.documentFileName"
+				fn-filename fn-extension="{{extension}}" fn-error="fileNameExtError">
+		</div>
+
 		<div class="form-group" x-show-errors>
 			<label for="documentAuthor" class="control-label">Author(s)</label>
 			<input class="form-control" id="documentAuthor" name="documentAuthor" type="text" ng-model="doc.documentAuthor" ng-blur="validate()">
@@ -43,11 +51,6 @@
 					<li data-ng-repeat="category in doc.documentCategories">{{category}}</li>
 				</ul>
 			</span>
-		</div>
-
-		<div ng-if="doc._schemaName === 'Document'" class="form-group file-type" x-show-errors>
-			<label for="documentFileName" class="control-label">File Name</label>
-			<input class="form-control" id="documentFileName" name="documentFileName" type="text" ng-model="doc.documentFileName" ng-blur="validate()">
 		</div>
 
 		<div class="row form-group">

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -508,18 +508,16 @@
 											<li data-ng-repeat="category in documentMgr.infoPanel.data.documentCategories">{{category}}</li>
 										</ul>
 									</span>
-								</li>
-								<!--
-								<li>
-									<span class="name">File Name:</span>
-									<span class="value">{{ documentMgr.infoPanel.data.documentFileName }}</span>
-								</li>
-								-->
-								<li class="doc-keywords-list" ng-if="documentMgr.infoPanel.data.keywords">
-									<span class="name">Keyword(s):</span>
-									<ul>
-										<li data-ng-repeat="keyword in documentMgr.infoPanel.data.keywords">{{ keyword }}</li>
-									</ul>
+                </li>
+                <li>
+                  <span class="name">File Name:</span>
+                  <span class="value">{{ documentMgr.infoPanel.data.documentFileName }}</span>
+                </li>
+                <li class="doc-keywords-list" ng-if="documentMgr.infoPanel.data.keywords">
+                  <span class="name">Keyword(s):</span>
+                  <ul>
+                    <li data-ng-repeat="keyword in documentMgr.infoPanel.data.keywords">{{ keyword }}</li>
+                  </ul>
 								</li>
 								<li>
 									<span class="name">Collections:</span>

--- a/modules/documents/server/controllers/core.document.controller.js
+++ b/modules/documents/server/controllers/core.document.controller.js
@@ -41,10 +41,20 @@ module.exports = DBModel.extend ({
 			this.setForce(true);
 			return doc;
 		}
+
+		//
+		// Make sure there is a value for displayName and documentFileName based on the original.
+		//
+		if (_.isEmpty(doc.displayName)) {
+			doc.displayName = doc.internalOriginalName;
+		}
+		if (_.isEmpty(doc.documentFileName)) {
+			doc.documentFileName = doc.internalOriginalName;
+		}
+
 		//
 		// check if there is an existing matching document
 		//
-
 		return this.findOne ({
 			project 		: doc.project,
 			documentIsLatestVersion	: true,

--- a/modules/documents/server/models/document.model.js
+++ b/modules/documents/server/models/document.model.js
@@ -118,7 +118,7 @@ module.exports = genSchema ('Document', {
 	projectFolderAuthor     : { type:String, default:'' },
 	documentEPICId          : { type:Number, default:0, index:true },
 	documentEPICProjectId   : { type:Number, default:0, index:true },
-	documentFileName        : { type:String, default:'' }, // A.K.A. Document File Name in EPIC
+	documentFileName        : { type:String, default:'' }, // the name of the file when downloaded
 	documentFileURL         : { type:String, default:'' },
 	documentFileSize        : { type:String, default:'' }, // Looks like everything is in KB
 	documentFileFormat      : { type:String, default:'' },

--- a/modules/documents/server/routes/core.document.routes.js
+++ b/modules/documents/server/routes/core.document.routes.js
@@ -99,17 +99,8 @@ module.exports = function (app) {
 			if (req.Document.internalURL.match (/^(http|ftp)/)) {
 				res.redirect (req.Document.internalURL);
 			} else {
-				// ETL fixing - if the name was brought in without a filename, and we have their document
-				// file format, affix the type as an extension to the original name so they have a better
-				// chance and opening up the file on double-click.
-				String.prototype.endsWith = String.prototype.endsWith || function (str){
-					return new RegExp(str + "$").test(str);
-				};
-				console.log("fetching:",req.Document.internalOriginalName,":", req.Document.documentFileFormat);
-				var name = req.Document.internalOriginalName;
-				if (req.Document.documentFileFormat && !req.Document.internalOriginalName.endsWith(req.Document.documentFileFormat)) {
-					name = req.Document.internalOriginalName + "." + req.Document.documentFileFormat;
-				}
+				var name = req.Document.documentFileName;
+
 				routes.streamFile (res, {
 					file : req.Document.internalURL,
 					name : name,

--- a/scripts/etlDisplayName.js
+++ b/scripts/etlDisplayName.js
@@ -1,0 +1,47 @@
+/**
+ * Script to fill empty document display and file name fields with the original file name.
+ * This script was run on MEM-ADMIN Test and Prod July 7, 2017
+ */
+'use strict';
+var etl = require('./etlHelper');
+
+var host = "localhost";
+var db = "esm";
+var username = "";
+var password = "";
+var authSource = "";
+
+// sample setting to connect to prod from a pod on prod.
+// do a db backup first
+// oc rsh mongo-pod
+//mongodump --authenticationDatabase=admin -db=esm  --username=admin --password=xxxx
+// then oc rsh another pod .. adjust the following and run.
+host = "172.50.11.87";
+username = "admin";
+password = "xxxx";
+authSource = "admin";
+
+var connectionString = etl.composeConnectString(host, db, username, password, authSource);
+
+var query1 = { $or: [ {displayName: {$eq: null}}, {displayName: {$eq: ''}} ] };
+var callback1 = function (document) {
+	return new Promise(function (resolve, reject) {
+		document.displayName = document.internalOriginalName;
+		return resolve(document);
+	});
+};
+
+var query2 = { $or: [ {documentFileName: {$eq: null}}, {documentFileName: {$eq: ''}} ] };
+var callback2 = function (document) {
+	return new Promise(function (resolve, reject) {
+		document.documentFileName = document.internalOriginalName;
+		return resolve(document);
+	});
+};
+
+console.log("Starting ETL.");
+
+etl.runUpdate(connectionString,'documents', query1, callback1);
+
+etl.runUpdate(connectionString,'documents', query2, callback2);
+

--- a/scripts/etlHelper.js
+++ b/scripts/etlHelper.js
@@ -1,0 +1,122 @@
+/**
+ * ETL helper.
+ * Usage
+ * var etl = require('./etlHelper');
+ * var connectionString = etl.composeConnectString(host, db, username, password, authSource);
+ * etl.runUpdate(connectionString, collectionName, query, updateDocCallback);
+ */
+'use strict';
+var MongoClient = require('mongodb').MongoClient;
+var LIMIT = 2000;
+
+// Is this needed for invalid certs?
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
+process.on('unhandledRejection', function (error, promise) {
+	console.error("UNHANDLED REJECTION", error, error.stack);
+});
+process.on('uncaughtException', function (error) {
+	console.error("UNCAUGHT EXCEPTION", error, error.stack);
+});
+
+
+module.exports = {
+	composeConnectString: composeConnectString,
+	runUpdate: runUpdate,
+	pingTest: pingTest
+};
+
+function composeConnectString(host, db, username, password, authSource) {
+	var connectionString = "mongodb://";
+	if (username.length>0) {
+		connectionString += username + ":" + password + "@";
+	}
+	connectionString += host + ":27017/" + db;
+	if (authSource) {
+		connectionString += "?authSource=" + authSource;
+	}
+	return connectionString;
+}
+
+function pingTest(connectionString, collectionName, query) {
+	var qStr = JSON.stringify(query);
+	console.log("Try connection with ", connectionString);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			console.log("connected ... next try query");
+			var collection = db.collection(collectionName);
+			// first check there are records because cursor.forEach() hangs on empty result sets.
+			collection.find(query).count()
+			.then(function (cnt) {
+					console.log("Query resulted found " + cnt + " records");
+					db.close();
+					return resolve(0);
+			});
+		});
+	});
+}
+
+/*
+ Run batches of size LIMIT until there are no more records that match the query.
+ */
+function runUpdate(connectionString, collectionName, query, updateDocCallback) {
+	return batchUpdate(connectionString, collectionName, query, updateDocCallback)
+	.then(function (cnt) {
+		if (cnt > 0) {
+			runUpdate.bind(null)(connectionString, collectionName, query, updateDocCallback);
+		} else {
+			console.log("Done ETL for query ", JSON.stringify(query));
+		}
+	})
+}
+
+/*
+ Run the update on a set of documents. Returns (promise) the count of remaining records needing update.
+ */
+function batchUpdate(connectionString, collectionName, query, updateCallback) {
+	var qStr = JSON.stringify(query);
+	return new Promise(function (resolve, reject) {
+		MongoClient.connect(connectionString, function (err, db) {
+			if (err) {
+				return reject(err);
+			}
+			var collection = db.collection(collectionName);
+			// first check there are records because cursor.forEach() hangs on empty result sets.
+			collection.find(query).count()
+			.then(function (cnt) {
+				if (cnt === 0) {
+					console.log("No results for query ", qStr);
+					db.close();
+					return resolve(0);
+				} else {
+					console.log("Update batch ", qStr);
+					var pending = 0;
+					var cursor = collection.find(query).limit(LIMIT).forEach(function (document) {
+						pending++;
+						updateCallback(document)
+						.then(function (d) {
+							collection.update({_id: d._id}, {$set: d}, function (err, result) {
+								if (err) {
+									db.close();
+									return reject(err);
+								}
+								pending--;
+								if (pending === 0) {
+									// exit for each .. we're done .. return count of remaining records
+									collection.find(query).count()
+									.then(function (cnt) {
+										console.log("Done batch   ", qStr, " remaining cnt: ", cnt);
+										db.close();
+										return resolve(cnt);
+									})
+								}
+							});
+						})
+					});
+				}
+			});
+		});
+	});
+}

--- a/scripts/etlPing.js
+++ b/scripts/etlPing.js
@@ -1,0 +1,28 @@
+/**
+ * Script to fill empty document display and file name fields with the original file name.
+ */
+'use strict';
+var etl = require('./etlHelper');
+
+var host = "localhost";
+var db = "esm";
+var username = "";
+var password = "";
+var authSource = "";
+
+// sample setting to connect to prod from a pod on prod.
+// oc rsh <a pod on prod>
+// .. adjust the following and run.
+host = "172.50.11.87";
+username = "admin";
+password = "xxx";
+authSource = "admin";
+
+var connectionString = etl.composeConnectString(host, db, username, password, authSource);
+
+var query1 = { $or: [ {displayName: {$eq: null}}, {displayName: {$eq: ''}} ] };
+
+console.log("Starting Ping.");
+
+etl.pingTest(connectionString,'documents', query1);
+


### PR DESCRIPTION
The document display and file names are now populated when the document is created. The ETL scripts have been run on TEST and PROD and should be run again once this code is promoted.
Now that the fields are guaranteed to be populated we can clean up a lot of code that did the work on the client side.
Can now edit the file name.
Add a filename validation and editing directive. Provides service to make sure a file name is valid and the original file extension can not be modified.
