### PR TITLE
MEM-398 fix multi-drag outside window

### DIFF
--- a/modules/collections/client/directives/collections.reorder.js
+++ b/modules/collections/client/directives/collections.reorder.js
@@ -119,16 +119,6 @@ function collectionsSortingController($scope, $document, $timeout) {
 
 	function onDragstart(event, idPrefix) {
 		vm.dragging = true;
-		var selected = vm.list.filter(function(item) {
-			return item.selected;
-		});
-		$timeout(function() {
-			selected.forEach(function (item) {
-				var dom = $document[0].getElementById(idPrefix+item.document._id);
-				var element = angular.element(dom);
-				element.addClass("dndDraggingSource");
-			});
-		}, 0);
 	}
 
 	function onDragend() {


### PR DESCRIPTION
Fixes edge case. Multi-select and drag outside window and release mouse.  The css class that hides elements was not removed from the drag set.  This commit resolves the issue.