### PR TITLE
Fix edit close only on cancel or save

### DIFF
--- a/modules/documents/client/directives/documents.manager.edit.directive.js
+++ b/modules/documents/client/directives/documents.manager.edit.directive.js
@@ -12,6 +12,8 @@ angular.module('documents')
 				element.on('click', function () {
 					$modal.open({
 						animation: true,
+						backdrop: 'static',
+						keyboard: false,
 						templateUrl: 'modules/documents/client/views/document-manager-edit.html',
 						resolve: {
 							obj: function(Document, FolderModel) {


### PR DESCRIPTION
Prevent accidental closing the edit dialog by background click or ESC key.