### PR TITLE
EPIC-1156 MEM-440 Prevent deletion of published content.

### DIFF
--- a/modules/core/client/scss/core.scss
+++ b/modules/core/client/scss/core.scss
@@ -3685,3 +3685,4 @@ tmpl-template-render {
 @import "modules/projects/client/scss/projects-abstract.scss";
 @import "modules/recent-activity/client/scss/recent-activity.scss";
 @import "modules/documents/client/components/doc-categories/doc-categories";
+@import "modules/documents/client/styles/documents.confirm.scss";

--- a/modules/core/server/controllers/core.dbmodel.controller.js
+++ b/modules/core/server/controllers/core.dbmodel.controller.js
@@ -433,6 +433,9 @@ _.extend (DBModel.prototype, {
 	deleteDocument : function (doc) {
 		var self = this;
 		return new Promise (function (resolve, reject) {
+			if((doc._schemaName === "Document" || doc._schemaName === "Folder" ) && doc.isPublished) {
+				return reject (new Error ('Cannot delete published content'));
+			}
 			doc.remove ().then (resolve, self.complete (reject, 'deletedocument'));
 		});
 	},

--- a/modules/documents/client/directives/documents.confirm.delete.directive.js
+++ b/modules/documents/client/directives/documents.confirm.delete.directive.js
@@ -1,0 +1,220 @@
+'use strict';
+angular.module('documents')
+.directive('confirmDelete', ['ConfirmDeleteService', function (ConfirmDeleteService) {
+	// x-confirm-delete
+	return {
+		restrict: 'A',
+		scope: {
+			files: '=',
+			folders: '=',
+			project: '=',
+			currentNode: '=',
+			deleteCallback: '='
+		},
+		link: function (scope, element, attrs) {
+			element.on('click', function () {
+				ConfirmDeleteService.confirmDialog(scope);
+			});
+		}
+	};
+}])
+.service('ConfirmDeleteService', ['$rootScope', '$modal', '_', '$timeout', 'DocumentMgrService', function ($rootScope, $modal, _, $timeout, DocumentMgrService) {
+	var service = this;
+	service.confirmDialog = function(scope) {
+		return new Promise(function(fulfill, reject) {
+			$modal.open({
+				animation: true,
+				templateUrl: 'modules/documents/client/views/partials/modal-document-confirm-delete.html',
+				resolve: {},
+				size: 'lg',
+				controllerAs: 'confirmDlg',
+				controller: function ($scope, $modalInstance) {
+					var NO_AUTH         = "Not authorized to delete";
+					var WONT_PUBLISHED  = "Published content will not be deleted";
+					var CANT_PUBLISHED  = "Published content cannot be deleted";
+					var WONT_CONTENT    = "Folders with content will not be deleted";
+					var CANT_CONTENT    = "Folders with content cannot be deleted";
+					var UNDELETABLE     = 'Any content showing a warning will not be deleted.';
+
+					var self = this;
+					/*
+						Set the following to true, during development, if you want to test the server side delete API.
+						This will bypass the client side tests and send all selected files or folders.
+						This is also a good way to test the client side error handling.
+					 */
+					self.testServerAPI = false;
+
+					self.busy           = true;
+					self.deleteCallback = scope.deleteCallback;
+					self.currentNode    = scope.currentNode;
+					self.project        = scope.project;
+					self.submit         = submit;
+					self.cancel         = cancel;
+
+					// Initialize ....
+					init();
+
+					function init() {
+						self.files             = collect(scope.files);
+						self.folders           = collect(scope.folders);
+						// the combined list is used by the ng-repeat
+						self.combindedList     = self.folders.concat(self.files);
+						self.deletableFolders  = _.filter(self.folders, function (item) {
+							return item.canBeDeleted;
+						});
+						self.deletableFiles    = _.filter(self.files, function (item) {
+							return item.canBeDeleted;
+						});
+						checkFoldersForContent()
+						.then (function () {
+							// repeat filter on folders
+							self.deletableFolders  = _.filter(self.folders, function (item) {
+								return item.canBeDeleted;
+							});
+							updateText();
+							self.busy = false;
+						});
+					}
+
+					// collect deletable folders and files
+					function collect(items) {
+						if (!items ) {
+							return [];
+						}
+						// service may be invoked on a single folder or file ....
+						items = Array.isArray(items) ? items : [ items ];
+						var results = _.map(items, function(item) {
+							var fClone = _.clone(item /* shallow clone */);
+							if (fClone.type === 'File') {
+								// file clone has f.isPublished and f.displayName
+								fClone.userCanDelete  = item.userCan.delete;
+								fClone.type           = ['png','jpg','jpeg'].indexOf(fClone.internalExt) > -1 ? 'Picture' : 'File';
+							} else {
+								fClone.userCanDelete  = self.project.userCan.manageFolders;
+								fClone.type           = 'Folder';
+								fClone.displayName    = item.model.name;
+								fClone.isPublished    = item.model.published;
+							}
+							fClone.canBeDeleted   = fClone.userCanDelete && !fClone.isPublished;
+							return fClone;
+						});
+						return results;
+					}
+
+					function checkFoldersForContent() {
+						var promises = [];
+						_.forEach(self.deletableFolders, function(fldr) {
+							// Does the folder have child folders? ....
+							var node = self.currentNode.first(function (child) {
+								return (child.model.id === fldr.model.id);
+							});
+							fldr.hasChildren = node.hasChildren();
+							fldr.canBeDeleted = !fldr.hasChildren;
+							if (fldr.canBeDeleted) {
+								// Does the folder have document content?....
+								promises.push(new Promise (function (resolve, reject) {
+									DocumentMgrService.getDirectoryDocuments(self.project, fldr.model.id)
+									.then(function (result) {
+										fldr.hasChildren = result.data.length > 0;
+										fldr.canBeDeleted = !fldr.hasChildren;
+										return resolve(fldr);
+									})
+									.catch(function (err) {
+										console.log("Error", err);
+										return reject(err);
+									});
+								}));
+							}
+						});
+						if (promises.length === 0) {
+							// Folders have no content or content is only folders
+							return Promise.resolve();
+						} 
+						// else some folders might have document content run all promises in array
+						return Promise.all(promises);
+					}
+
+					function updateText() {
+						var folderCnt          = self.folders.length;
+						var fileCnt            = self.files.length;
+						var deletableFolderCnt = self.deletableFolders.length;
+						var deletableFileCnt   = self.deletableFiles.length;
+						self.allBlocked        = false;
+						self.hasBlockedContent = false;
+
+						if (deletableFolderCnt > 0 || deletableFileCnt > 0) {
+							if (folderCnt > deletableFolderCnt || fileCnt > deletableFileCnt ) {
+								self.hasBlockedContent = true;
+								self.bannerText = "Some content has been published. Content MUST be unpublished before it can be deleted";
+								self.confirmText  += " " + UNDELETABLE;
+							}
+							var fText            = deletableFileCnt > 1 ? "Files" : deletableFileCnt === 1 ? "File" : "";
+							var fldrText         = deletableFolderCnt > 1 ? "Folders" : deletableFolderCnt === 1 ? "Folder" : "";
+							var combinedText     = fText + ((fText && fldrText) ? " and " : "") + fldrText;
+							var confirmText      = 'Are you sure you want to permanently delete the following ' + combinedText.toLowerCase() + '?';
+							var warning          = 'This action CANNOT be undone.';
+							self.title           = "Confirm Delete " + combinedText;
+							self.confirmText     = confirmText + " " + warning;
+							if (self.hasBlockedContent) {
+								self.confirmText   += " " + UNDELETABLE;
+							}
+							self.showSubmit      = true;
+							self.cancelText      = 'No';
+						} else {
+							// No files and no folders can be deleted
+							self.allBlocked           = true;
+							if (self.testServerAPI) {
+								self.title         = "Confirm Delete API Testing";
+								self.showSubmit    = true;
+								self.cancelText    = 'cancel';
+
+							} else {
+								self.title         = "Published content cannot be deleted";
+								self.showSubmit    = false;
+								self.cancelText    = 'OK';
+								self.hasBlockedContent = true;
+								self.bannerText    = "Content MUST be unpublished before it can be deleted";
+							}
+						}
+						// update the text why a user can not delete an item...
+						_.forEach(self.folders, function (item) {
+							setReasonForItem(item);
+						});
+						_.forEach(self.files, function (item) {
+							setReasonForItem(item);
+						});
+					}
+
+					function setReasonForItem(item) {
+						if (!item.canBeDeleted) {
+							item.reason = (
+								!item.userCanDelete   ? NO_AUTH :
+								item.isPublished      ? (self.allBlocked ? CANT_PUBLISHED : WONT_PUBLISHED) :
+								item.hasChildren      ? (self.allBlocked ? CANT_CONTENT : WONT_CONTENT)     : ""
+							);
+						}
+					}
+
+					function cancel() {
+						$modalInstance.dismiss('cancel');
+					}
+
+					function submit () {
+						self.busy = true;
+						var folders = self.testServerAPI ? self.folders : self.deletableFolders;
+						var files = self.testServerAPI ? self.files : self.deletableFiles;
+						self.deleteCallback(folders,files)
+						.then(function (result) {
+							self.busy = false;
+							$modalInstance.close(result);
+						}, function (err) {
+							self.busy = false;
+							self.errMsg = err.message;
+							$scope.$apply();
+						});
+					}
+				}
+			});
+		});
+	};
+}]);

--- a/modules/documents/client/directives/documents.manager.directive.js
+++ b/modules/documents/client/directives/documents.manager.directive.js
@@ -426,144 +426,82 @@ angular.module('documents')
 						});
 				};
 
-				self.deleteDir = function(doc) {
-					self.busy = true;
-					return DocumentMgrService.removeDirectory($scope.project, doc)
-						.then(function (result) {
-							$scope.project.directoryStructure = result.data;
-							$scope.$broadcast('documentMgrRefreshNode', {directoryStructure: result.data});
-							self.busy = false;
-							AlertService.success('The selected folder was deleted.');
-						}, function(docs) {
-							var msg = "";
-							var theDocs = [];
-							if (docs.data.message && docs.data.message[0] && docs.data.message[0].displayName) {
-								_.each(docs.data.message, function (d) {
-									theDocs.push(d.displayName);
-								});
-								msg = 'This action cannot be completed as the following documents are in the folder: ' + theDocs + '.';
-							} else {
-								msg = "Could not delete folder, there are still files in the folder.";
-							}
-
-							$log.error('DocumentMgrService.removeDirectory error: ', msg);
-							self.busy = false;
-							AlertService.error(msg);
-						});
-				};
-
-				self.deleteFile = function(doc) {
-					self.busy = true;
-					return self.deleteDocument(doc._id)
-						.then(function(result) {
-							self.selectNode(self.currentNode.model.id); // will mark as not busy...
-							var name = doc.displayName;
-							AlertService.success('Delete File', 'The selected file was deleted.');
-						}, function(error) {
-							$log.error('deleteFile error: ', JSON.stringify(error));
-							self.busy = false;
-							AlertService.error('The selected file could not be deleted.');
-						});
+				self.deleteDocument = function(documentID) {
+					return Document.lookup(documentID)
+					.then( function (doc) {
+						return Document.getProjectDocumentVersions(doc._id);
+					})
+					.then( function (docs) {
+						// Are there any prior versions?  If so, make them the latest and then delete
+						// otherwise delete
+						if (docs.length > 0) {
+							return Document.makeLatestVersion(docs[docs.length-1]._id);
+						} else {
+							return null;
+						}
+					})
+					.then( function () {
+						// Delete it from the system.
+						return Document.deleteDocument(documentID);
+					});
 				};
 
 				self.deleteSelected = {
-					titleText: 'Delete File(s)',
-					okText: 'Yes',
-					cancelText: 'No',
-					ok: function() {
-						/*
-							Here the user has selected OK on the confirm dialog. We need to show the progress which is behind the
-							confirm dialog. To do this we'll place the long running task in a setImmediate and return from this
-							ok method.
-						*/
-						var dirs = _.size(self.checkedDirs);
-						var files = _.size(self.checkedFiles);
-						if (dirs === 0 && files === 0) {
-							return Promise.resolve();
-						} else {
-							$timeout(doDelete, 10);
-							return Promise.resolve();
-						}
-						// do the work ....
-						function doDelete() {
-							self.busy = true;
-
-							var dirPromises = _.map(self.deleteSelected.deleteableFolders, function(d) {
-								return DocumentMgrService.removeDirectory($scope.project, d);
-							});
-
-							var filePromises = _.map(self.deleteSelected.deleteableFiles, function(f) {
-								return self.deleteDocument(f._id);
-							});
-
-							var directoryStructure;
-							return Promise.all(dirPromises)
-								.then(function(result) {
-									//$log.debug('Dir results ', JSON.stringify(result));
-									if (!_.isEmpty(result)) {
-										var last = _.last(result);
-										directoryStructure = last.data;
-									}
-									return Promise.all(filePromises);
-								})
-								.then(function(result) {
-									//$log.debug('File results ', JSON.stringify(result));
-									if (directoryStructure) {
-										//$log.debug('Setting the new directory structure...');
-										$scope.project.directoryStructure = directoryStructure;
-										$scope.$broadcast('documentMgrRefreshNode', { directoryStructure: directoryStructure });
-									}
-									//$log.debug('Refreshing current directory...');
-									self.selectNode(self.currentNode.model.id);
-									self.busy = false;
-									AlertService.success('The selected items were deleted.');
-								}, function(err) {
-									self.busy = false;
-									AlertService.error('The selected items could not be deleted.');
-								});
-						}
-					},
-					cancel: undefined,
-					confirmText:  'Are you sure you want to delete the selected item(s)?',
 					confirmItems: [],
-					deleteableFolders: [],
-					deleteableFiles: [],
 					setContext: function() {
 						self.deleteSelected.confirmItems = [];
-						self.deleteSelected.titleText = 'Delete selected';
-						self.deleteSelected.confirmText = 'Are you sure you want to delete the following the selected item(s)?';
-						var dirs = _.size(self.checkedDirs);
-						var files = _.size(self.checkedFiles);
-						if (dirs > 0 && files > 0) {
-							self.deleteSelected.titleText = 'Delete Folder(s) and File(s)';
-							self.deleteSelected.confirmText = 'Are you sure you want to delete the following ('+ dirs +') folders and ('+ files +') files?';
-						} else if (dirs > 0) {
-							self.deleteSelected.titleText = 'Delete Folder(s)';
-							self.deleteSelected.confirmText = 'Are you sure you want to delete the following ('+ dirs +') selected folders?';
-						} else if (files > 0) {
-							self.deleteSelected.titleText = 'Delete File(s)';
-							self.deleteSelected.confirmText = 'Are you sure you want to delete the following ('+ files +') selected files?';
-						}
-
-						self.deleteSelected.confirmItems = [];
-						self.deleteSelected.deleteableFolders = [];
-						self.deleteSelected.deleteableFiles = [];
-
 						_.each(self.checkedDirs, function(o) {
 							if ($scope.project.userCan.manageFolders) {
 								self.deleteSelected.confirmItems.push(o.model.name);
-								self.deleteSelected.deleteableFolders.push(o);
 							}
 						});
 						_.each(self.checkedFiles, function(o) {
 							if (o.userCan.delete) {
-								var name = o.displayName;
-								self.deleteSelected.confirmItems.push(name);
-								self.deleteSelected.deleteableFiles.push(o);
+								self.deleteSelected.confirmItems.push(o.displayName);
 							}
 						});
-
 					}
+				};
+
+				// callback invoked by delete directive once user confirms delete
+				self.deleteFilesAndDirs = function(deletableFolders, deletableFiles) {
+					self.busy = true;
+
+					var dirPromises = _.map(deletableFolders, function(d) {
+						return DocumentMgrService.removeDirectory($scope.project, d);
+					});
+
+					var filePromises = _.map(deletableFiles, function(f) {
+						return self.deleteDocument(f._id);
+					});
+
+					var directoryStructure;
+					return Promise.all(dirPromises)
+					.then(function(result) {
+						// console.log("Delete folders result", result);
+						//$log.debug('Dir results ', JSON.stringify(result));
+						if (!_.isEmpty(result)) {
+							var last = _.last(result);
+							directoryStructure = last.data;
+						}
+						return Promise.all(filePromises);
+					})
+					.then(function(result) {
+						//$log.debug('File results ', JSON.stringify(result));
+						if (directoryStructure) {
+							//$log.debug('Setting the new directory structure...');
+							$scope.project.directoryStructure = directoryStructure;
+							$scope.$broadcast('documentMgrRefreshNode', { directoryStructure: directoryStructure });
+						}
+						//$log.debug('Refreshing current directory...');
+						self.selectNode(self.currentNode.model.id);
+						self.busy = false;
+						AlertService.success('The selected items were deleted.');
+					}, function(err) {
+						console.log("err result", err);
+						self.busy = false;
+						AlertService.error('The selected items could not be deleted.');
+					});
 				};
 
 				self.publishFiles = function(files) {

--- a/modules/documents/client/styles/documents.confirm.scss
+++ b/modules/documents/client/styles/documents.confirm.scss
@@ -1,0 +1,49 @@
+// For the Delete files and folders confirmation directive
+
+// some styling can be found in file-browser.scss. Not the file with that name adjacent to this stylesheet
+// It's in the file in core/client/scss/components
+/*
+.confirm-dialog .confirm-list {
+  margin-top: 1rem;
+  margin-bottom: 0;
+  font-weight: bold; }
+*/
+
+.confirm-dialog ul {
+  list-style-type: none;
+  padding-left: 0;
+
+  &>li {
+    background-color: #fff;
+    padding: 2rem;
+    border-bottom: 1px solid #eee;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
+  }
+  .disabled {
+    color: #ddd;
+  }
+}
+
+
+
+.confirm-list .avatar {
+  font-weight: normal;
+  flex: 0 0 5%;
+}
+
+.confirm-list .item {
+  font-weight: normal;
+  flex: 1 1 45%;
+}
+
+.confirm-list .reason {
+  font-weight: normal;
+  color: red;
+  flex: 0 1 50%;
+  text-align: right;
+}
+
+
+

--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -53,13 +53,13 @@
 					<li>
 						<a title="Delete"
 							ng-hide="documentMgr.deleteSelected.confirmItems.length === 0"
-							x-confirm-dialog
-							x-title-text="documentMgr.deleteSelected.titleText"
-							x-ok-text="documentMgr.deleteSelected.okText"
-							x-cancel-text="documentMgr.deleteSelected.cancelText"
-							x-confirm-text="documentMgr.deleteSelected.confirmText"
-							x-confirm-items="documentMgr.deleteSelected.confirmItems"
-							x-on-ok="documentMgr.deleteSelected.ok"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+               x-confirm-delete
+               x-delete-callback="documentMgr.deleteFilesAndDirs"
+               x-current-node="documentMgr.currentNode"
+               x-project="project"
+               x-folders="documentMgr.checkedDirs"
+               x-files="documentMgr.checkedFiles">
+              <span class="glyphicon glyphicon-trash"></span> Delete</a>
 					</li>
 					<li>
 						<a title="Publish"
@@ -215,14 +215,11 @@
 											</li>
 											<li ng-if="project.userCan.manageFolders">
 												<button class="btn icon-btn" title="Delete Folder" ng-click="$event.stopPropagation();"
-														x-confirm-dialog
-														x-title-text="'Delete Folder'"
-														x-ok-text="'Yes'"
-														x-cancel-text="'No'"
-														x-confirm-text="'Are you sure you want to delete this folder? This action cannot be undone.'"
-														x-confirm-items="[doc.model.folderObj.displayName]"
-														x-on-ok="documentMgr.deleteDir"
-																x-ok-args="doc">
+                          x-confirm-delete
+                          x-delete-callback="documentMgr.deleteFilesAndDirs"
+                          x-current-node="documentMgr.currentNode"
+                          x-project="project"
+                          x-folders="doc">
 													<span class="glyphicon glyphicon-trash"></span>
 												</button>
 											</li>
@@ -342,14 +339,11 @@
 											</li>
 											<li ng-if="doc.userCan.delete">
 												<button class="btn icon-btn" title="Delete File" ng-click="$event.stopPropagation();"
-														x-confirm-dialog
-														x-title-text="'Delete File(s)'"
-														x-ok-text="'Yes'"
-														x-cancel-text="'No'"
-														x-confirm-text="'Are you sure you want to delete this file? This action cannot be undone.'"
-														x-confirm-items="[doc.displayName]"
-														x-on-ok="documentMgr.deleteFile"
-														x-ok-args="doc">
+                          x-confirm-delete
+                          x-current-node="documentMgr.currentNode"
+                          x-project="project"
+                          x-delete-callback="documentMgr.deleteFilesAndDirs"
+                          x-files="doc">
 													<span class="glyphicon glyphicon-trash"></span>
 												</button>
 											</li>
@@ -416,14 +410,12 @@
 								<li ng-if="documentMgr.infoPanel.data.userCan.delete">
 									<a title="Delete File"
 										ng-click="$event.stopPropagation();"
-										x-confirm-dialog
-										x-title-text="'Delete File(s)'"
-										x-ok-text="'Yes'"
-										x-cancel-text="'No'"
-										x-confirm-text="'Are you sure you want to delete this file? This action cannot be undone.'"
-										x-confirm-items="[documentMgr.infoPanel.data.displayName]"
-										x-on-ok="documentMgr.deleteFile"
-										x-ok-args="documentMgr.infoPanel.data"><span class="glyphicon glyphicon-trash"></span> Delete</a>
+                    x-confirm-delete
+                    x-current-node="documentMgr.currentNode"
+                    x-project="project"
+                    x-delete-callback="documentMgr.deleteFilesAndDirs"
+                    x-files="documentMgr.infoPanel.data">
+                    <span class="glyphicon glyphicon-trash"></span> Delete</a>
 								</li>
 								<li ng-if="documentMgr.infoPanel.data.userCan.publish && !documentMgr.infoPanel.data.isPublished">
 									<a title="Publish File"

--- a/modules/documents/client/views/partials/modal-document-confirm-delete.html
+++ b/modules/documents/client/views/partials/modal-document-confirm-delete.html
@@ -1,0 +1,39 @@
+<div class="spinner-container" ng-show="confirmDlg.busy">
+  <div class="spinner-new rotating"></div>
+</div>
+
+<form class="confirm-dialog">
+	<div class="modal-header">
+		<button class="btn btn-default close" type="button" ng-click="confirmDlg.cancel()">
+			<span aria-hidden="true">&times;</span>
+		</button>
+		<h3 class="modal-title">{{confirmDlg.title}}</h3>
+	</div>
+
+	<div class="modal-body" ng-if="confirmDlg.errMsg">
+		<div class="alert alert-danger" >{{confirmDlg.errMsg}}</div>
+	</div>
+
+  <div class="modal-body"  ng-if="!confirmDlg.errMsg">
+    <div class="alert alert-danger" ng-if="confirmDlg.hasBlockedContent">{{confirmDlg.bannerText}}</div>
+
+		{{confirmDlg.confirmText}}
+		<ul class="confirm-list">
+			<li  ng-repeat="item in confirmDlg.combindedList">
+        <span class="avatar" ng-class="{'disabled': !item.canBeDeleted}">
+          <span class="fb-folder glyphicon glyphicon-folder-close" ng-if="item.type === 'Folder'"></span>
+          <span class="fb-file glyphicon glyphicon-file" ng-if="item.type === 'File'"></span>
+          <span class="fb-img glyphicon glyphicon-picture" ng-if="item.type === 'Picture'"></span>
+        </span>
+        <span class="item" ng-class="{'disabled': !item.canBeDeleted}" >{{item.displayName}}</span>
+        <span class="reason" ng-show="!item.canBeDeleted">{{item.reason}}</span>
+      </li>
+		</ul>
+	</div>
+
+	<div class="modal-footer">
+		<button class="btn btn-default" type="button" ng-click="confirmDlg.cancel()">{{confirmDlg.cancelText}}</button>
+		<button class="btn btn-primary" type="submit" ng-click="confirmDlg.submit()"
+			ng-show="confirmDlg.showSubmit" ng-disabled="confirmDlg.errMsg">Yes</button>
+	</div>
+</form>


### PR DESCRIPTION
The main new rule is to not let the user delete published content. Existing rules include prevention of folders with content and user permissions.
There are 5 ways to delete content. 
1. Info panel. Select a document and open the info panel. Try deleting a published and unpublished file.
2. Row item delete. Open the ellipse menu for a published document. Click the delete icon. Repeat for a unpublished document.
3. Repeat #2 on a published and unpublished folder.4. Select various files and folders and use the batch menu delete (top right side above document list).

Scenarios to test:

- Only published folders
- Only published files
- Only unpublished folders
- Only unpublished files
- Mix published folders and unpublished folders
- Mix published files and unpublished files
- Mix published and unpublished folders and files.
- Only folders with content
- Repeat above mixing in folders with content
- 

This dialog also handles the case a user is not authorized to delete a file or files and the case a user can not manage folders.

Note that the system has a defect with multiple folder deletes. After a multiple delete operation the user must refresh the page to get the results.