### PR TITLE
EM-498 change for MEM Document Manager

### DIFF
--- a/modules/documents/client/views/document-manager.html
+++ b/modules/documents/client/views/document-manager.html
@@ -278,9 +278,11 @@
 								</span>
 								<span hidden class="col author-col" title="{{ doc.documentAuthor }}">
 									{{ doc.documentAuthor }}
-								</span>
-								<span class="col date-added-col">{{ doc.documentDate | documentDateFilter: doc.documentDateDisplayMnYr }}</span>
-								<span class="col status-col last-col" ng-if="authentication.user">
+                </span>
+                <span class="col date-added-col">
+                  {{ doc.inspectionReport.dateResponse ? doc.inspectionReport.dateResponse :  doc.documentDate | documentDateFilter: doc.documentDateDisplayMnYr }}
+                </span>
+                <span class="col status-col last-col" ng-if="authentication.user">
 									<span class="label label-success" ng-if="doc.isPublished && documentMgr.currentPathIsPublished" title="Published">Published</span>
 									<span class="label label-unpublished" ng-if="doc.isPublished && !documentMgr.currentPathIsPublished" title="Published">Published</span>
 									<span class="label label-unpublished" ng-if="!doc.isPublished">Unpublished</span>


### PR DESCRIPTION
> Inspection Report Response Dates not Displaying in Document Manager

- Inserted logic to determine if there is an inspectionReport.dateResponse, and if so, display that in the document manager instead. Other documents should be unaffected by this change.