### PR TITLE
EM-218 hotfix for MEM

### DIFF
--- a/modules/collections/server/controllers/collections.controller.js
+++ b/modules/collections/server/controllers/collections.controller.js
@@ -281,9 +281,11 @@ module.exports = DBModel.extend({
 
           // Remove from Collection
           docList = _.without(docList, collectionDocument);
-          collection.hasPublished = _.find(docList, function(o) {
-            return o.document.isPublished
-          });
+          if (docType == 'main') {
+            collection.hasPublished = _.find(docList, function(o) {
+              return o.document.isPublished
+            });
+          }
           collection.save();
 
           // Remove from CollectionDocument


### PR DESCRIPTION
- Fixed a bug where removing the last published 'related document' would flag the whole collection as not having a published 'main document'.