### PR TITLE
EM-564: Collections - Link Document Interface Renders all documents that are already linked.

### DIFF
--- a/modules/collections/client/views/collection-edit.html
+++ b/modules/collections/client/views/collection-edit.html
@@ -118,10 +118,9 @@
           </div>
 
           <div class="btn-toolbar">
-            <button class="btn btn-info" title="Link main document to this collection"
+            <button class="btn btn-info" title="Add main documents to this collection"
               x-document-mgr-link-modal
               x-project="project"
-              x-target="modifiedDocuments.main"
               x-collection="collection"
               x-doc-type="main"
               x-on-ok="updateDocuments">
@@ -163,9 +162,9 @@
         <fieldset>
           <legend>Related Documents</legend>
           <div class="btn-toolbar">
-            <button class="btn btn-info" title="Link other documents to this collection"
-              x-document-mgr-link-modal x-project="project"
-              x-target="modifiedDocuments.other"
+            <button class="btn btn-info" title="Add related documents to this collection"
+              x-document-mgr-link-modal
+              x-project="project"
               x-collection="collection"
               x-doc-type="other"
               x-on-ok="updateDocuments">

--- a/modules/documents/client/directives/documents.manager.link.directive.js
+++ b/modules/documents/client/directives/documents.manager.link.directive.js
@@ -229,12 +229,12 @@ angular.module('documents')
               $scope.project = scope.project;
               $scope.authentication = Authentication;
 
-              self.title = "Link Documents to '" + $scope.project.name + "'";
+              self.title = "Add Documents to '" + $scope.project.name + "'";
               if (!_.isEmpty(scope.collection.displayName)) {
-                self.title = "Link Documents to '" + scope.collection.displayName + "'";
+                self.title = "Add Documents to '" + scope.collection.displayName + "'";
               }
 
-              self.linkedFiles = angular.copy(scope.target || []);
+              self.linkedFiles = [];
               self.publishedOnly = scope.publishedOnly;
               self.docType = scope.docType;
               self.sourceDocs = {

--- a/modules/documents/client/views/document-manager-link.html
+++ b/modules/documents/client/views/document-manager-link.html
@@ -120,15 +120,15 @@
     </div>
 </section>
 
-<!-- Linked Files Section -->
+<!-- Selected Files Section -->
 <section>
-    <label>Linked Files ({{linkedFiles.length}})</label>
+    <label>Selected Files ({{linkedFiles.length}})</label>
     <div class="fb-body">
         <div class="fb-list">
             <ul>
                 <li class="fb-list-item" ng-if="linkedFiles.length == 0">
                     <span class="col first-col">
-                        No Documents linked.
+                        No Documents selected.
                     </span>
                 </li>
                 <li class="fb-list-item" ng-repeat="doc in linkedFiles">
@@ -151,4 +151,4 @@
             </ul>
         </div>
     </div>
-</section><!-- / Linked Files Section -->
+</section><!-- / Selected Files Section -->


### PR DESCRIPTION
- Changes to the modal informing users that these are 'selected documents' and not 'linked documents'
- Modified the controller to check incoming (selected) docs against both the 'Main' and 'Related' documents lists. This alleviates the need for a separate 'findDuplicates' function.