### PR TITLE
Enable autofix for eslint errors

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -71,7 +71,8 @@ module.exports = function(grunt) {
     eslint: {
       target: 'modules/**/*.js',
       options: {
-        configFile: '.eslintrc'
+        configFile: '.eslintrc',
+        fix: true
       }
     },
     csslint: {

--- a/modules/core/client/directives/header.client.directives.js
+++ b/modules/core/client/directives/header.client.directives.js
@@ -10,12 +10,11 @@ angular.module('core')
     return {
       restrict    : 'E',
       templateUrl : 'modules/core/client/views/header.client.view.html',
-      controller  : function ($scope, Authentication, Menus, _, ENV, Application, ADMIN_FEATURES) {
-        $scope.application 		= Application;
-        $scope.authentication 	= Authentication;
-        $scope.ENV				= ENV;
-        $scope.ADMIN_FEATURES	= ADMIN_FEATURES;
-        $scope.systemMenu		= Menus.getMenu ('systemMenu');
+      controller  : function ($scope, Authentication, Menus, _, ENV, Application) {
+        $scope.application = Application;
+        $scope.authentication = Authentication;
+        $scope.ENV = ENV;
+        $scope.systemMenu = Menus.getMenu ('systemMenu');
         // -------------------------------------------------------------------------
         //
         // literally toggle the side menu
@@ -34,16 +33,6 @@ angular.module('core')
           side.toggleClass('col-sm-2 col-0');
         };
 
-        //
-        // CC: not needed with permissions
-        //
-        // $scope.isAdmin = (Authentication.user && Authentication.user.roles.indexOf ('admin') !== -1);
-        // if ($scope.project) {
-        // 	$scope.isEAO = (Authentication.user && (!!~Authentication.user.roles.indexOf ($scope.project.code+':eao:member') || !!~Authentication.user.roles.indexOf ('admin')));
-        // }
-        // $scope.isProjectAdmin = false;
-        // $scope.isProponentAdmin = false;
-
         // -------------------------------------------------------------------------
         //
         // really do need to watch here as this directive sits above ui-router resolves
@@ -52,38 +41,8 @@ angular.module('core')
         $scope.$watch('project', function(newValue) {
           if (newValue) {
             $scope.project = newValue;
-            //
-            // CC: not needed with permissions
-            //
-            // $scope.isProjectAdmin = (Authentication.user && Authentication.user.roles.indexOf ($scope.project.adminRole) !== -1);
-            // $scope.isProponentAdmin = (Authentication.user && Authentication.user.roles.indexOf ($scope.project.proponentAdminRole) !== -1);
           }
         });
-
-        // -------------------------------------------------------------------------
-        //
-        // not sure if these are still used, or even the side menu with them
-        //
-        // -------------------------------------------------------------------------
-        // $scope.pageAnchors = function(id) {
-        // 	// get all links in the container.
-        // 	if (!id) {
-        // 		return;
-        // 	}
-        // 	var showParent = false;
-        // 	var links = document.querySelectorAll ('#' + id + ' a');
-        // 	_.each(links, function(link) {
-        // 		if ($scope.showMenu( angular.element(link).attr('href') )) {
-        // 			// just need one to show the parent.
-        // 			showParent = true;
-        // 			angular.element(link).removeClass('ng-hide');
-        // 		} else {
-        // 			angular.element(link).addClass('ng-hide');
-        // 		}
-        // 	});
-        // 	return showParent;
-        // };
-
       }
     };
   });


### PR DESCRIPTION
Enable eslint autofix for errors that can be addressed automatically (spacing, indentation, see [here](https://eslint.org/docs/rules/) for additional reference).