### PR TITLE
WIP: file proxy for Minio downloads

### DIFF
--- a/modules/core/server/controllers/core.minio.controller.js
+++ b/modules/core/server/controllers/core.minio.controller.js
@@ -24,7 +24,7 @@ exports.BUCKETS = BUCKETS;
 /**
  * Checks wether the provided bucket name is a valid (known) bucket.
  * @param bucket the name of the bucket
- * @return true if the bucket is valid, false otherwise
+ * @returns true if the bucket is valid, false otherwise
  */
 var isValidBucket = function (bucket) {
   if (bucket) {
@@ -39,7 +39,7 @@ var isValidBucket = function (bucket) {
 
 /**
  * Returns a 16-bit pseudo-random string to be used as file name for the storage.
- * @return a 16-bit pseudo-random string
+ * @returns a 16-bit pseudo-random string
  * @see https://github.com/expressjs/multer/blob/ee5188d7499dd19c8596fe011e6f6e53ea4778d6/storage/disk.js#L7-L11
  */
 var getRandomizedFileName = function () {
@@ -48,7 +48,7 @@ var getRandomizedFileName = function () {
 
 /**
  * Return the file extension, derived from the full file name
- * @return the file extension (ex: soemfile.txt => txt), or null if not extension is found (ex: somefile => null).
+ * @returns the file extension (ex: soemfile.txt => txt), or null if not extension is found (ex: somefile => null).
  */
 var getFileExtension = function (fileName) {
   return fileName.match(/\.([0-9a-z]+$)/i)[1];
@@ -57,7 +57,7 @@ var getFileExtension = function (fileName) {
 /**
  * Creates a Minio bucket with the given name
  * @param bucket the name of the bucket
- * @return a promise that resolves if the bucket was created successfully
+ * @returns a promise that resolves if the bucket was created successfully
  */
 var makeBucket = function (bucket) {
   return minioClient.makeBucket(bucket);
@@ -66,7 +66,7 @@ var makeBucket = function (bucket) {
 /**
  * Checks if the provided bucket name exists on Minio
  * @param bucket the name of the bucket
- * @return a promise that resolves with true if the bucket exists, false otherwise
+ * @returns a promise that resolves with true if the bucket exists, false otherwise
  */
 var bucketExists = function (bucket) {
   return minioClient.bucketExists(bucket);
@@ -79,7 +79,7 @@ var bucketExists = function (bucket) {
  * @param projectCode a project code
  * @param fileName the name of the file
  * @param pathOnDisk the path to the file being uploaded
- * @return a promise that resolves with an object containing the uploaded file information
+ * @returns a promise that resolves with an object containing the uploaded file information
  */
 var putDocument = function (bucket, projectCode, fileName, pathOnDisk) {
   if (isValidBucket(bucket)) {
@@ -132,7 +132,7 @@ exports.deleteDocument = deleteDocument;
  * The url can be used multiple times, but expires after 5 minutes.
  * @param bucket the name of the bucket where the object is stored
  * @param filePath the file path for the file to retrieve.  Typically something like "some-gold-mine/thisisarandomizedbtyestring12345.pdf"
- * @return a promise that resolves with the presigned url
+ * @returns a promise that resolves with the presigned url
  */
 var getPresignedGETUrl = function (bucket, filePath) {
   return minioClient.presignedGetObject(bucket, filePath, 5 * 60)
@@ -144,6 +144,23 @@ var getPresignedGETUrl = function (bucket, filePath) {
     });
 };
 exports.getPresignedGETUrl = getPresignedGETUrl;
+
+/**
+ * Gets the metadata for the specified object
+ * @param bucketName the name of the bucket where the object is stored
+ * @param objectName the name of the object being checked
+ * @returns a promise that resolves with the object metadata, or undefined if the object does not exist
+ */
+var statObject = function (bucketName, objectName) {
+  return minioClient.statObject(bucketName, objectName)
+    .then(function(stat, err){
+      if (err) {
+        return undefined;
+      }
+      return stat;
+    });
+}
+exports.statObject = statObject;
 
 /**
  * Wrappers for the above functions to add support for http request/response.

--- a/modules/documents/server/routes/core.document.routes.js
+++ b/modules/documents/server/routes/core.document.routes.js
@@ -6,12 +6,16 @@
 // Does not use the normal crud routes, mostly special sauce
 //
 // =========================================================================
+var fs = require('fs');
+var Multer = require('multer');
+var os = require('os');
+var path = require('path');
+var rp = require('request-promise-native');
+
 var DocumentClass	= require ('../controllers/core.document.controller');
 var routes = require ('../../../core/server/controllers/core.routes.controller');
 var policy = require ('../../../core/server/controllers/core.policy.controller');
 var MinioController = require('../../../core/server/controllers/core.minio.controller');
-var fs = require('fs');
-var Multer = require('multer');
 
 module.exports = function (app) {
   //
@@ -108,12 +112,65 @@ module.exports = function (app) {
       if (req.Document.internalURL.match(/^(http|ftp)/)) {
         return res.redirect(req.Document.internalURL);
       } else {
-        return MinioController.getPresignedGETUrl(MinioController.BUCKETS.DOCUMENTS_BUCKET, req.Document.internalURL)
+        var fileName = req.Document.displayName;
+        var tmpFile = path.join(os.tmpdir(), fileName);
+        var fileMeta;
+
+        // check if the file exists in Minio
+        return MinioController.statObject(MinioController.BUCKETS.DOCUMENTS_BUCKET, req.Document.internalURL)
+          .then(function(objectMeta){
+            if(!objectMeta){
+              renderNotFound(req.originalUrl, res);
+            }
+            fileMeta = objectMeta;
+            // get the download URL
+            return MinioController.getPresignedGETUrl(MinioController.BUCKETS.DOCUMENTS_BUCKET, req.Document.internalURL);
+          })
           .then(function (docURL) {
-            res.redirect(docURL);
+            // download file from Minio to local file system
+            return rp(docURL).pipe(fs.createWriteStream(tmpFile));
+          })
+          .then(function (wStream) {
+            // wait for the file to be available, and stream it back in the response
+            return new Promise(function(resolve){
+              wStream.on('close', function(){
+                var stream 	= fs.createReadStream(tmpFile);
+                res.setHeader('Content-Length', fileMeta.size);
+                res.setHeader('Content-Type', fileMeta.metaData['content-type']);
+                res.setHeader('Content-Disposition', 'attachment;filename="' + fileName + '"');
+                stream.pipe(res);
+                resolve();
+              })
+            });
+          })
+          .then(function(){
+            // remove tmpFile
+            fs.unlink(tmpFile);
+          })
+          .catch(function(){
+            // remove tmpFile
+            fs.unlink(tmpFile);
           });
       }
     });
+
+  function renderNotFound (url, res) {
+    res.status(404).format({
+      'text/html': function () {
+        res.render('modules/core/server/views/404', {
+          url: url
+        });
+      },
+      'application/json': function () {
+        res.json({
+          error: 'Path not found'
+        });
+      },
+      'default': function () {
+        res.send('Path not found');
+      }
+    });
+  }
 
   /**
    * Adds a new commentDocument to Minio and a new database record for the given file.

--- a/modules/documents/server/routes/core.document.routes.js
+++ b/modules/documents/server/routes/core.document.routes.js
@@ -122,7 +122,7 @@ module.exports = function (app) {
    */
   app.route ('/api/commentdocument/:project/upload')
     .all (policy ('guest'))
-    .post (Multer({storage: Multer.diskStorage()}).single('file'), // upload using multer
+    .post (Multer({storage: Multer.diskStorage({})}).single('file'), // upload using multer
       routes.setAndRun (DocumentClass, function (model, req) {
         if (req.file) {
           return MinioController.putDocument(MinioController.BUCKETS.DOCUMENTS_BUCKET, req.Project.code, req.file.originalname, req.file.path)
@@ -193,7 +193,7 @@ module.exports = function (app) {
    */
   app.route ('/api/document/:project/upload')
     .all (policy ('guest'))
-    .post (Multer({storage: Multer.diskStorage()}).single('file'), // upload using multer
+    .post (Multer({storage: Multer.diskStorage({})}).single('file'), // upload using multer
       routes.setAndRun (DocumentClass, function (model, req) {
         if (req.file) {
           return MinioController.putDocument(MinioController.BUCKETS.DOCUMENTS_BUCKET, req.Project.code, req.file.originalname, req.file.path)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mongodb-core": "3.0.8",
     "mongoose": "4.13.8",
     "morgan": "1.9.0",
-    "multer": "^1.3.1",
+    "multer": "1.3.1",
     "node-pre-gyp": "0.10.0",
     "nodemailer": "2.3.2",
     "passport": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "passport-unique-token": "0.1.4",
     "promise": "8.0.1",
     "qs": "6.5.2",
+    "request": "2.88.0",
+    "request-promise-native": "1.0.5",
     "rss": "1.2.2",
     "serve-favicon": "2.5.0",
     "socket.io": "2.1.1",

--- a/scripts/minio/README.md
+++ b/scripts/minio/README.md
@@ -1,6 +1,6 @@
 # Minio update scripts
 
-This folder contains scripts that can/should be used to update teh database data in order to make it compatible with Minio.
+This folder contains scripts that can/should be used to update the database data in order to make it compatible with Minio.
 
 To execute the script, copy the file to the container running mongo and then issue the following command:
 `mongo -u admin -p $MONGODB_ADMIN_PASSWORD --authenticationDatabase=admin localhost:27017/$MONGODB_DATABASE updateInternalURL.js`

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,11 @@ aws4@^1.6.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
   integrity sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==
 
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
 axios@^0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
@@ -1272,6 +1277,13 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   integrity sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -2351,6 +2363,11 @@ extend@3, extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
   integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
@@ -2651,7 +2668,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.0, form-data@~2.3.1:
+form-data@~2.3.0, form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
@@ -3205,6 +3222,14 @@ har-validator@~5.0.3:
   integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  integrity sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==
+  dependencies:
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
@@ -4402,6 +4427,11 @@ lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.4, l
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
   integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
 
+lodash@^4.13.1:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
 lodash@~4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
@@ -4664,6 +4694,11 @@ mime-db@~1.35.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
   integrity sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==
 
+mime-db@~1.36.0:
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+  integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
+
 mime-types@2.1.13:
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
@@ -4698,6 +4733,13 @@ mime-types@~2.1.16:
   integrity sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
   dependencies:
     mime-db "~1.30.0"
+
+mime-types@~2.1.19:
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
+  integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
+  dependencies:
+    mime-db "~1.36.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -5359,6 +5401,11 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
   integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
 oauth@0.9.x:
   version "0.9.15"
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
@@ -5957,6 +6004,11 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+  integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
+
 pump@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.2.tgz#3b3ee6512f94f0e575538c17995f9f16990a5d51"
@@ -5994,7 +6046,7 @@ qs@6.5.1, qs@^6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@6.5.2, qs@~6.5.1:
+qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -6294,6 +6346,22 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  integrity sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  integrity sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
 request@2, request@2.81.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -6348,6 +6416,32 @@ request@2.75.x:
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
+
+request@2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 request@^2.0.0, request@^2.74.0:
   version "2.87.0"
@@ -6572,6 +6666,11 @@ safe-buffer@5.1.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
   integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
+
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -7185,6 +7284,11 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -7540,6 +7644,14 @@ tosource@^1.0.0:
   resolved "https://registry.yarnpkg.com/tosource/-/tosource-1.0.0.tgz#42d88dd116618bcf00d6106dd5446f3427902ff1"
   integrity sha1-QtiN0RZhi88A1hBt1URvNCeQL/E=
 
+tough-cookie@>=2.3.3, tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -7823,6 +7935,11 @@ uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
   integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uws@~0.14.4:
   version "0.14.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4933,7 +4933,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-multer@^1.3.1:
+multer@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/multer/-/multer-1.3.1.tgz#c3fb3b35f50c7eefe873532f90d3dde02ce6e040"
   integrity sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==


### PR DESCRIPTION
DO NOT MERGE UNTIL WORK HAS BEEN CHECKED AND COMPLETED

This PR contains the changes required to add a download proxy for files stored in Minio, so that the original `/fetch` url will appear/be used in the browser instead of the Minio one.

The changes are complete and working, HOWEVER more research effort needs to be scheduled before merging them since it appears that NodeJS is having some issues handling files that are larger than 256Mb (which is the max buffer size in NodeJS). The issue is: when uploading or downloading a large file, the file transfer completes correctly, but an error resulting in the pod being restarted occurs.

The implementation uses Multer for multipart file upload, and NodeJS streams to handle the file download and proxying so it is a bit surprising that problems are surfacing.